### PR TITLE
change: go module name to pulse227

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # zagane
 
-[![CircleCI](https://circleci.com/gh/gcpug/zagane.svg?style=svg)](https://circleci.com/gh/gcpug/zagane)
-[![GoDoc](https://godoc.org/github.com/gcpug/zagane?status.svg)](https://godoc.org/github.com/gcpug/zagane)
+[![CircleCI](https://circleci.com/gh/pulse227/zagane.svg?style=svg)](https://circleci.com/gh/pulse227/zagane)
+[![GoDoc](https://godoc.org/github.com/pulse227/zagane?status.svg)](https://godoc.org/github.com/pulse227/zagane)
 
 `zagane` is a static analysis tool which can find bugs in spanner's code.
 `zagane` consists of several analyzers.
@@ -15,7 +15,7 @@
 You can get `zagane` by `go get` command.
 
 ```bash
-$ go get -u github.com/gcpug/zagane
+$ go get -u github.com/pulse227/zagane
 ```
 
 ## How to use
@@ -23,8 +23,8 @@ $ go get -u github.com/gcpug/zagane
 `zagane` run with `go vet` as below when Go is 1.12 and higher.
 
 ```bash
-$ go vet -vettool=$(which zagane) github.com/gcpug/spshovel/...
-# github.com/gcpug/spshovel/spanner
+$ go vet -vettool=$(which zagane) github.com/pulse227/spshovel/...
+# github.com/pulse227/spshovel/spanner
 spanner/spanner_service.go:29:29: iterator must be stop
 ```
 
@@ -32,8 +32,8 @@ When Go is lower than 1.12, just run `zagane` command with the package name (imp
 But it cannot accept some options such as `--tags`.
 
 ```bash
-$ zagane github.com/gcpug/spshovel/...
-~/go/src/github.com/gcpug/spshovel/spanner/spanner_service.go:29:29: iterator must be stop
+$ zagane github.com/pulse227/spshovel/...
+~/go/src/github.com/pulse227/spshovel/spanner/spanner_service.go:29:29: iterator must be stop
 ```
 
 ## Analyzers
@@ -128,7 +128,7 @@ _, _ = client.Single().Query(ctx, stmt).Next()
 
 ## Analyze with golang.org/x/tools/go/analysis
 
-You can get analyzers of zagane from [zagane.Analyzers](https://godoc.org/github.com/gcpug/zagane/zagane/#Analyzers).
+You can get analyzers of zagane from [zagane.Analyzers](https://godoc.org/github.com/pulse227/zagane/zagane/#Analyzers).
 And you can use them with [unitchecker](https://golang.org/x/tools/go/analysis/unitchecker).
 
 ## Why name is "zagane"?

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gcpug/zagane
+module github.com/pulse227/zagane
 
 go 1.15
 

--- a/main.go
+++ b/main.go
@@ -1,9 +1,10 @@
+//go:build !go1.12
 // +build !go1.12
 
 package main
 
 import (
-	"github.com/gcpug/zagane/passes/unstopiter"
+	"github.com/pulse227/zagane/passes/unstopiter"
 	"golang.org/x/tools/go/analysis/singlechecker"
 )
 

--- a/main_go112.go
+++ b/main_go112.go
@@ -1,9 +1,10 @@
+//go:build go1.12
 // +build go1.12
 
 package main
 
 import (
-	"github.com/gcpug/zagane/zagane"
+	"github.com/pulse227/zagane/zagane"
 	"golang.org/x/tools/go/analysis/unitchecker"
 )
 

--- a/passes/unclosetx/plugin/main.go
+++ b/passes/unclosetx/plugin/main.go
@@ -1,11 +1,11 @@
 // This file can build as a plugin for golangci-lint by below command.
-//    go build -buildmode=plugin -o unclosetx.so github.com/gcpug/zagane/passes/unclosetx/plugin
+//    go build -buildmode=plugin -o unclosetx.so github.com/pulse227/zagane/passes/unclosetx/plugin
 // See: https://golangci-lint.run/contributing/new-linters/#how-to-add-a-private-linter-to-golangci-lint
 
 package main
 
 import (
-	"github.com/gcpug/zagane/passes/unclosetx"
+	"github.com/pulse227/zagane/passes/unclosetx"
 	"golang.org/x/tools/go/analysis"
 )
 

--- a/passes/unclosetx/unclosetx.go
+++ b/passes/unclosetx/unclosetx.go
@@ -6,10 +6,10 @@ import (
 	"go/types"
 	"strings"
 
-	"github.com/gcpug/zagane/zaganeutils"
 	"github.com/gostaticanalysis/analysisutil"
 	"github.com/gostaticanalysis/comment"
 	"github.com/gostaticanalysis/comment/passes/commentmap"
+	"github.com/pulse227/zagane/zaganeutils"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/buildssa"
 	"golang.org/x/tools/go/ssa"

--- a/passes/unclosetx/unclosetx_test.go
+++ b/passes/unclosetx/unclosetx_test.go
@@ -3,8 +3,8 @@ package unclosetx_test
 import (
 	"testing"
 
-	"github.com/gcpug/zagane/passes/unclosetx"
 	"github.com/gostaticanalysis/testutil"
+	"github.com/pulse227/zagane/passes/unclosetx"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 

--- a/passes/unstopiter/plugin/main.go
+++ b/passes/unstopiter/plugin/main.go
@@ -1,11 +1,11 @@
 // This file can build as a plugin for golangci-lint by below command.
-//    go build -buildmode=plugin -o unstopiter.so github.com/gcpug/zagane/passes/unstopiter/plugin
+//    go build -buildmode=plugin -o unstopiter.so github.com/pulse227/zagane/passes/unstopiter/plugin
 // See: https://golangci-lint.run/contributing/new-linters/#how-to-add-a-private-linter-to-golangci-lint
 
 package main
 
 import (
-	"github.com/gcpug/zagane/passes/unstopiter"
+	"github.com/pulse227/zagane/passes/unstopiter"
 	"golang.org/x/tools/go/analysis"
 )
 

--- a/passes/unstopiter/unstopiter.go
+++ b/passes/unstopiter/unstopiter.go
@@ -6,10 +6,10 @@ import (
 	"go/types"
 	"strings"
 
-	"github.com/gcpug/zagane/zaganeutils"
 	"github.com/gostaticanalysis/analysisutil"
 	"github.com/gostaticanalysis/comment"
 	"github.com/gostaticanalysis/comment/passes/commentmap"
+	"github.com/pulse227/zagane/zaganeutils"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/buildssa"
 )

--- a/passes/unstopiter/unstopiter_test.go
+++ b/passes/unstopiter/unstopiter_test.go
@@ -3,8 +3,8 @@ package unstopiter_test
 import (
 	"testing"
 
-	"github.com/gcpug/zagane/passes/unstopiter"
 	"github.com/gostaticanalysis/testutil"
+	"github.com/pulse227/zagane/passes/unstopiter"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 

--- a/passes/wraperr/plugin/main.go
+++ b/passes/wraperr/plugin/main.go
@@ -1,11 +1,11 @@
 // This file can build as a plugin for golangci-lint by below command.
-//    go build -buildmode=plugin -o wraperr.so github.com/gcpug/zagane/passes/wraperr/plugin
+//    go build -buildmode=plugin -o wraperr.so github.com/pulse227/zagane/passes/wraperr/plugin
 // See: https://golangci-lint.run/contributing/new-linters/#how-to-add-a-private-linter-to-golangci-lint
 
 package main
 
 import (
-	"github.com/gcpug/zagane/passes/wraperr"
+	"github.com/pulse227/zagane/passes/wraperr"
 	"golang.org/x/tools/go/analysis"
 )
 

--- a/passes/wraperr/wraperr.go
+++ b/passes/wraperr/wraperr.go
@@ -5,10 +5,10 @@ import (
 	"go/token"
 	"go/types"
 
-	"github.com/gcpug/zagane/zaganeutils"
 	"github.com/gostaticanalysis/analysisutil"
 	"github.com/gostaticanalysis/comment"
 	"github.com/gostaticanalysis/comment/passes/commentmap"
+	"github.com/pulse227/zagane/zaganeutils"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/buildssa"
 	"golang.org/x/tools/go/ssa"

--- a/passes/wraperr/wraperr_test.go
+++ b/passes/wraperr/wraperr_test.go
@@ -3,8 +3,8 @@ package wraperr_test
 import (
 	"testing"
 
-	"github.com/gcpug/zagane/passes/wraperr"
 	"github.com/gostaticanalysis/testutil"
+	"github.com/pulse227/zagane/passes/wraperr"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -1,13 +1,13 @@
 // This file can build as a plugin for golangci-lint by below command.
-//    go build -buildmode=plugin -o zagane.so github.com/gcpug/zagane/plugin
+//    go build -buildmode=plugin -o zagane.so github.com/pulse227/zagane/plugin
 // See: https://golangci-lint.run/contributing/new-linters/#how-to-add-a-private-linter-to-golangci-lint
 
 package main
 
 import (
-	"github.com/gcpug/zagane/passes/unclosetx"
-	"github.com/gcpug/zagane/passes/unstopiter"
-	"github.com/gcpug/zagane/passes/wraperr"
+	"github.com/pulse227/zagane/passes/unclosetx"
+	"github.com/pulse227/zagane/passes/unstopiter"
+	"github.com/pulse227/zagane/passes/wraperr"
 	"golang.org/x/tools/go/analysis"
 )
 

--- a/zagane/analyzers.go
+++ b/zagane/analyzers.go
@@ -1,9 +1,9 @@
 package zagane
 
 import (
-	"github.com/gcpug/zagane/passes/unclosetx"
-	"github.com/gcpug/zagane/passes/unstopiter"
-	"github.com/gcpug/zagane/passes/wraperr"
+	"github.com/pulse227/zagane/passes/unclosetx"
+	"github.com/pulse227/zagane/passes/unstopiter"
+	"github.com/pulse227/zagane/passes/wraperr"
 	"golang.org/x/tools/go/analysis"
 )
 


### PR DESCRIPTION
https://github.com/golang/go/issues/50278

現在、フォークしたリポジトリを go install する際に replace などできないらしい